### PR TITLE
In strava_oauth, check app_scope argument, set cache to TRUE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,4 +46,5 @@ Authors@R: c(
   	email = "niklasv@gmail.com"
   	)
   )
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
+Encoding: UTF-8

--- a/R/strava_oauth.R
+++ b/R/strava_oauth.R
@@ -5,8 +5,8 @@
 #' @param app_name chr string for name of the app
 #' @param app_client_id chr string for ID received when the app was registered
 #' @param app_secret chr string for secret received when the app was registered
-#' @param app_scope chr string for scope of authentication, Must be "read" , "read_all", "profile:read_all", "profile:write", "activity:read", "activity:read_all" or "activity:write"
-#' @param cache logical to cache the token
+#' @param app_scope chr string for scope of authentication, Must be one of "public", "read" , "read_all", "profile:read_all", "profile:write", "activity:read", "activity:read_all" or "activity:write"
+#' @param cache logical to cache the token, default is set
 #'
 #' @details The \code{app_name}, \code{app_client_id}, and \code{app_secret} are specific to the user and can be obtained by registering an app on the Strava API authentication page: \url{http://strava.github.io/api/v3/oauth/}.  This requires a personal Strava account.
 #'
@@ -37,8 +37,12 @@
 #' # use authentication token
 #' get_athlete(stoken, id = '2837007')
 #' }
-strava_oauth <- function(app_name, app_client_id, app_secret, app_scope = 'public', cache = FALSE){
-      
+strava_oauth <- function(app_name, app_client_id, app_secret,
+                         app_scope = c("public", "read" , "read_all", "profile:read_all", "profile:write", "activity:read", "activity:read_all", "activity:write"),
+                         cache = TRUE){
+
+        app_scope <- match.arg(app_scope)
+
 	strava_app <- oauth_app(appname = app_name, key = app_client_id, secret = app_secret)  
 	
 	strava_end <- oauth_endpoint(

--- a/man/strava_oauth.Rd
+++ b/man/strava_oauth.Rd
@@ -8,8 +8,9 @@ strava_oauth(
   app_name,
   app_client_id,
   app_secret,
-  app_scope = "public",
-  cache = FALSE
+  app_scope = c("public", "read", "read_all", "profile:read_all", "profile:write",
+    "activity:read", "activity:read_all", "activity:write"),
+  cache = TRUE
 )
 }
 \arguments{
@@ -19,9 +20,9 @@ strava_oauth(
 
 \item{app_secret}{chr string for secret received when the app was registered}
 
-\item{app_scope}{chr string for scope of authentication, Must be "read" , "read_all", "profile:read_all", "profile:write", "activity:read", "activity:read_all" or "activity:write"}
+\item{app_scope}{chr string for scope of authentication, Must be one of "public", "read" , "read_all", "profile:read_all", "profile:write", "activity:read", "activity:read_all" or "activity:write"}
 
-\item{cache}{logical to cache the token}
+\item{cache}{logical to cache the token, default is set}
 }
 \value{
 A \code{Token2.0} object returned by \code{\link[httr]{oauth2.0_token}} to be used with API function calls


### PR DESCRIPTION
Closes #110 

As discussed in #110, this checks the scope argument by using `match.arg()` against the set of values set in the signature.  If you wanted to keep the function signature short, you can keep it as before and rely of `stopifnot()` e.g. something like

```r
values <- c("public", "read" , "read_all", "profile:read_all", "profile:write", 
            "activity:read", "activity:read_all", "activity:write")
stopifnot("Argument 'app_scope' must use one of a set of value" = is.na(match(app_scope, values))))
```

I go back and forth between the simple use of `match.arg()` and the ability to customize the message via `stopifnot()`.  

The PR also flips `cache` to TRUE as a default value.  Lastly, `roxygen2` noted we should set 'Encoding: UTF-8' so that was added as well.